### PR TITLE
fix(types): Fix ParamSpec import

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,7 @@ setup_requires =
     pytest-runner
 install_requires =
     makefun>=1.5.0
-    typing-extensions>=4.2;python_version>'3.6' and python_version<'3.10'
+    typing-extensions>=4.2
     # note: do not use double quotes in these, this triggers a weird bug in PyCharm in debug mode only
     funcsigs;python_version<'3.3'
     enum34;python_version<'3.4'

--- a/src/decopatch/main.pyi
+++ b/src/decopatch/main.pyi
@@ -1,11 +1,6 @@
 from typing import Any, Callable, Optional, Protocol, TypeVar, overload
 
-try:
-    # We're importing typing_extensions version first, becouse it will
-    # detect best available implementation depending on python version.
-    from typing_extensions import ParamSpec
-except ImportError:
-    from typing import ParamSpec
+from typing_extensions import ParamSpec
 
 from decopatch.utils_disambiguation import FirstArgDisambiguation
 from decopatch.utils_modes import SignatureInfo


### PR DESCRIPTION
Hi, this PR fixes a bug, which appears in new Pyright.

Apparently, we should not use try/except in pyi, and it was working before by mistake.

typing-extensions are already doing necessary if/else checks to use ParamSpec from `typing` depending on the Python version.

Refs https://github.com/microsoft/pyright/issues/8018