### PR TITLE
fix: pkg_resources is no longer available

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,13 +15,6 @@ See also:
 from setuptools import setup
 
 
-# (1) check required versions (from https://medium.com/@daveshawley/safely-using-setup-cfg-for-metadata-1babbe54c108)
-import pkg_resources
-
-pkg_resources.require("setuptools>=39.2")
-pkg_resources.require("setuptools_scm")
-
-
 # (2) Generate download url using git version
 from setuptools_scm import get_version  # noqa: E402
 


### PR DESCRIPTION
Refs https://setuptools.pypa.io/en/latest/history.html#v82-0-0